### PR TITLE
Add support for AWS Assume Role

### DIFF
--- a/roles/clouds/defaults/main.yml
+++ b/roles/clouds/defaults/main.yml
@@ -37,5 +37,6 @@ verify_ssl: true
 #       importExisting: "on"
 #       isVpc: "true"
 #       endpoint: "ec2.us-east-2.amazonaws.com"
-#       accessKey: AKXXXXXXXXXXXXXXXXXX
-#       secretKey: 'xxxxxxxxxxxxxxxxxxx'
+#       accessKey: "AKXXXXXXXXXXXXXXXXXX"
+#       secretKey: "xxxxxxxxxxxxxxxxxxx"
+#       stsAssumeRole: "arn:aws:iam::xxxxxxxxxxxx:role/xxxxxxxxxxxx"

--- a/roles/clouds/tasks/add_clouds.yml
+++ b/roles/clouds/tasks/add_clouds.yml
@@ -64,6 +64,7 @@
           secretKey: "{{ item.config.secretKey }}"
           vpc: "{{ item.config.vpc | default(omit) }}"
           isVpc: "{{ item.config.isVpc | default(omit) }}"
+          stsAssumeRole: "{{ item.config.stsAssumeRole | default(omit) }}"
   when: item.zoneType.code == "amazon"
 
 - name: Create cloud JSON payload for Azure


### PR DESCRIPTION
Adding support for AWS Assume Role. When creating a Cloud in Morpheus through the web portal, there is an option for specifying a "ROLE ARN". This pull requests adds feature parity for Ansible usage. Assume Role is described in the [AWS documentation](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
