### PR TITLE
Add httpapi plugin and facts module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.0
+- Added httpapi connection plugin
+- Added appliance_facts module
+
 ## v0.2.5
 - Added AWS assume role support to cloud role
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
       - [Cloud](#cloud)
     - [Token Requirement](#token-requirement)
     - [Troubleshooting](#troubleshooting)
+  - [httpapi Plugin Usage](#httpapi-plugin-usage)
+    - [Parameters](#parameters)
+    - [Example Inventory](#example-inventory)
   - [Ansible Roles for Morpheus Setup](#ansible-roles-for-morpheus-setup)
   - [Support Expectations](#support-expectations)
 
@@ -232,11 +235,46 @@ Information on encrypting strings and variables for ansible is located [HERE](ht
 
 By using `-vv` or higher whether using `ansible-inventory` or using the inventory in a playbook, the plugin will output extra information for use in troubleshooting.  Output will be prefixed by: `morpheus_inventory: `
 
+## httpapi Plugin Usage
+The httpapi plugin allows one to interact with Morpheus Appliances through Ansible modules by specifying appliances in Ansible Inventories.
+
+### Parameters
+The following Parameters are specific to this module. Other standard httpapi parameters apply.
+
+|Parameter|Comments|
+|---|---|
+|morpheus_user|Specifying a user will login to the api and retrieve an authentication token. <br /> **ANSIBLE_MORPHEUS_USER**|
+|morpheus_password|When using morpheus_user for authentication, morpheus_password should also be specified. <br /> **ANSIBLE_MORPHEUS_PASSWORD**|
+|morpheus_api_token|Use a pre-defined API Token instead of Username/Password. <br /> **ANSIBLE_MORPHEUS_TOKEN**
+
+### Example Inventory
+```yaml
+all:
+  hosts:
+    devcmp.example.tld:
+      ansible_morpheus_user: johndoe
+      ansible_morpheus_password: password
+    testcmp.example.tld:
+      ansible_morpheus_token: 12345abc-67de-89fa-12bc-345678defabc
+  vars:
+    ansible_network_os: morpheus.core.morpheus
+    ansible_httpapi_use_ssl: true
+```
+
+**Note:** It is not recommended to keep plaintext credentials in files. Where possible use Ansible Vault to encrypt secrets.
+
 ## Ansible Roles for Morpheus Setup
 
 These roles are designed for net new Morpheus configurations.  They are _NOT_ designed for removing existing items.
 
 See README files in `roles/` for information regarding the roles in this collection
+
+## Modules
+Individual Module Documentation can be found included with the module and can be viewed with ```ansible-doc -t module morpheus.core.module_name```
+
+|Module Name|Description|
+|---|---|
+|appliance_facts|Gathers appliance settings and license facts of the target Morpheus Appliance
 
 ## Support Expectations
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,16 +1,18 @@
 namespace: "morpheus"
 name: "core"
 description: Ansible collection for interacting with Morpheus
-version: "0.2.5"
+version: "0.3.0"
 readme: "README.md"
 authors:
     - "Nick Celebic (https://www.github.com/tryfan)"
+    - "James Riach (https://github.com/McGlovin1337)"
 license:
     - "MIT"
 tags:
     - morpheus
     - cloud
     - collection
+    - httpapi
 repository: "https://www.github.com/gomorpheus/ansible-collection-morpheus-core"
 build_ignore:
     - "Dockerfile"

--- a/plugins/httpapi/morpheus.py
+++ b/plugins/httpapi/morpheus.py
@@ -1,0 +1,138 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.basic import to_text
+from ansible.errors import AnsibleConnectionFailure, AnsibleOptionsError, AnsibleAuthenticationFailure
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.plugins.httpapi import HttpApiBase
+from ansible.module_utils.connection import ConnectionError
+import json
+import re
+
+DOCUMENTATION = r'''
+---
+author: James Riach
+httpapi : morpheus
+short_description: Httpapi Plugin for Morpheus
+description:
+  - Httpapi plugin to connect to and manage morpheus appliances through the morpheus api
+version_added: "0.3.0"
+options:
+    morpheus_user:
+        type: str
+        env:
+           - name: ANSIBLE_MORPHEUS_USER
+        vars:
+           - name: ansible_morpheus_user
+    morpheus_password:
+        type: str
+        env:
+           - name: ANSIBLE_MORPHEUS_PASSWORD
+        vars:
+           - name: ansible_morpheus_password
+    morpheus_api_token:
+        type: str
+        env:
+            - name: ANSIBLE_MORPHEUS_TOKEN
+        vars:
+            - name: ansible_morpheus_token
+'''
+
+LOGIN_PATH = '/oauth/token?client_id=morph-api&grant_type=password&scope=write'
+WHOAMI_PATH = '/api/whoami'
+
+BASE_HEADERS = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json'
+}
+
+
+class HttpApi(HttpApiBase):
+    def __init__(self, connection):
+        super(HttpApi, self).__init__(connection)
+        self.headers = BASE_HEADERS
+        self.access_token = None
+        self.refresh_token = None
+        self.token_timeout = None
+
+    def handle_httperror(self, exc):
+        # Handle 5xx errors
+        err_5xx = r'^5\d{2}$'
+
+        handled_error = re.search(err_5xx, str(exc.code))
+        if handled_error:
+            raise AnsibleConnectionFailure('Could not connect to {0}: {1}'.format(self.connection._url, exc.reason))
+
+        # Handle 401 errors
+        if exc.code == 401:
+            raise AnsibleAuthenticationFailure('Authentication Failure')
+
+        return False
+
+    def login(self, username, password):
+        # The specification of ansible_user results in Ansible attempting a HTTP Basic Auth attempt,
+        # this is incompatible with the morpheus login endpoint, therefore we raise an exception
+        if username and password:
+            raise AnsibleOptionsError('Cannot use ansible_user or ansible_password, refer to plugin documentation')
+
+        api_token = self.get_option('morpheus_api_token')
+
+        if api_token:
+            self.access_token = api_token
+            self.headers['Authorization'] = 'Bearer {0}'.format(self.access_token)
+
+            # Call the whoami endpoint as a means of checking token validity
+            response = self.send_request(path=WHOAMI_PATH)
+            return
+
+        username = self.get_option('morpheus_user')
+        password = self.get_option('morpheus_password')
+
+        if username and password:
+            payload = 'username={0}&password={1}'.format(username, password)
+            headers = {
+                'Accept': 'application/json',
+                'Content-Type': 'application/x-www-form-urlencoded'
+            }
+            response = self.send_request(payload, path=LOGIN_PATH, method='POST', headers=headers)
+
+            try:
+                self.access_token = response['contents']['access_token']
+                self.refresh_token = response['contents']['refresh_token']
+                self.token_timeout = response['contents']['expires_in']
+                self.headers['Authorization'] = 'Bearer {0}'.format(self.access_token)
+            except KeyError:
+                raise AnsibleAuthenticationFailure('Failed to retrieve an access_token: %s' % response)
+            return
+
+        raise AnsibleAuthenticationFailure('Username and Password or API Token required for login')
+
+    def send_request(self, data=None, **kwargs) -> dict:
+        path = kwargs.pop('path', None)
+        method = kwargs.pop('method', 'GET')
+        headers = kwargs.pop('headers', self.headers)
+
+        if headers['Content-Type'] != 'application/x-www-form-urlencoded':
+            data = json.dumps(data) if data is not None else None
+
+        try:
+            response, response_data = self.connection.send(path, data, method=method, headers=headers, **kwargs)
+        except HTTPError as exc:
+            try:
+                exc_data = self._response_to_json(exc.read())
+            except ConnectionError:
+                exc_data = exc.read()
+
+            return dict(code=exc.code, contents=exc_data, path=path)
+
+        response_value = self._get_response_value(response_data)
+        return dict(code=response.getcode(), contents=self._response_to_json(response_value))
+
+    def _get_response_value(self, response_data):
+        return to_text(response_data.getvalue())
+
+    def _response_to_json(self, response_text):
+        try:
+            return json.loads(response_text) if response_text else {}
+        except ValueError:
+            raise ConnectionError('Invalid JSON response: %s' % response_text)

--- a/plugins/module_utils/facts/appliance_database.py
+++ b/plugins/module_utils/facts/appliance_database.py
@@ -18,6 +18,6 @@ class MorpheusDatabaseFactCollector(BaseFactCollector):
 
         appliance_health = morph_api.get_appliance_health()
 
-        facts['database'] = appliance_health['health']['database']
+        facts['morpheus_database'] = appliance_health['health']['database']
 
         return facts

--- a/plugins/module_utils/facts/appliance_database.py
+++ b/plugins/module_utils/facts/appliance_database.py
@@ -1,0 +1,23 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+from ansible.module_utils.connection import Connection
+from ansible_collections.morpheus.core.plugins.module_utils.morpheusapi import MorpheusApi
+
+
+class MorpheusDatabaseFactCollector(BaseFactCollector):
+    name = 'database'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        facts = {}
+
+        connection = Connection(module._socket_path)
+        morph_api = MorpheusApi(connection)
+
+        appliance_health = morph_api.get_appliance_health()
+
+        facts['database'] = appliance_health['health']['database']
+
+        return facts

--- a/plugins/module_utils/facts/appliance_elastic.py
+++ b/plugins/module_utils/facts/appliance_elastic.py
@@ -18,6 +18,6 @@ class MorpheusElasticFactCollector(BaseFactCollector):
 
         appliance_health = morph_api.get_appliance_health()
 
-        facts['elastic'] = appliance_health['health']['elastic']
+        facts['morpheus_elastic'] = appliance_health['health']['elastic']
 
         return facts

--- a/plugins/module_utils/facts/appliance_elastic.py
+++ b/plugins/module_utils/facts/appliance_elastic.py
@@ -1,0 +1,23 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+from ansible.module_utils.connection import Connection
+from ansible_collections.morpheus.core.plugins.module_utils.morpheusapi import MorpheusApi
+
+
+class MorpheusElasticFactCollector(BaseFactCollector):
+    name = 'elastic'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        facts = {}
+
+        connection = Connection(module._socket_path)
+        morph_api = MorpheusApi(connection)
+
+        appliance_health = morph_api.get_appliance_health()
+
+        facts['elastic'] = appliance_health['health']['elastic']
+
+        return facts

--- a/plugins/module_utils/facts/appliance_license.py
+++ b/plugins/module_utils/facts/appliance_license.py
@@ -1,0 +1,23 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+from ansible.module_utils.connection import Connection
+from ansible_collections.morpheus.core.plugins.module_utils.morpheusapi import MorpheusApi
+
+
+class MorpheusLicenseFactCollector(BaseFactCollector):
+    name = 'license'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        facts = {}
+
+        connection = Connection(module._socket_path)
+        morph_api = MorpheusApi(connection)
+
+        appliance_license = morph_api.get_appliance_license()
+
+        facts['license'] = appliance_license['license']
+
+        return facts

--- a/plugins/module_utils/facts/appliance_license.py
+++ b/plugins/module_utils/facts/appliance_license.py
@@ -18,6 +18,6 @@ class MorpheusLicenseFactCollector(BaseFactCollector):
 
         appliance_license = morph_api.get_appliance_license()
 
-        facts['license'] = appliance_license['license']
+        facts['morpheus_license'] = appliance_license['license']
 
         return facts

--- a/plugins/module_utils/facts/appliance_rabbitmq.py
+++ b/plugins/module_utils/facts/appliance_rabbitmq.py
@@ -18,6 +18,6 @@ class MorpheusRabbitmqFactCollector(BaseFactCollector):
 
         appliance_health = morph_api.get_appliance_health()
 
-        facts['rabbitmq'] = appliance_health['health']['rabbit']
+        facts['morpheus_rabbitmq'] = appliance_health['health']['rabbit']
 
         return facts

--- a/plugins/module_utils/facts/appliance_rabbitmq.py
+++ b/plugins/module_utils/facts/appliance_rabbitmq.py
@@ -1,0 +1,23 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+from ansible.module_utils.connection import Connection
+from ansible_collections.morpheus.core.plugins.module_utils.morpheusapi import MorpheusApi
+
+
+class MorpheusRabbitmqFactCollector(BaseFactCollector):
+    name = 'rabbitmq'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        facts = {}
+
+        connection = Connection(module._socket_path)
+        morph_api = MorpheusApi(connection)
+
+        appliance_health = morph_api.get_appliance_health()
+
+        facts['rabbitmq'] = appliance_health['health']['rabbit']
+
+        return facts

--- a/plugins/module_utils/facts/appliance_settings.py
+++ b/plugins/module_utils/facts/appliance_settings.py
@@ -1,0 +1,23 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+from ansible.module_utils.connection import Connection
+from ansible_collections.morpheus.core.plugins.module_utils.morpheusapi import MorpheusApi
+
+
+class MorpheusSettingsFactCollector(BaseFactCollector):
+    name = 'settings'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        facts = {}
+
+        connection = Connection(module._socket_path)
+        morph_api = MorpheusApi(connection)
+
+        appliance_settings = morph_api.get_appliance_settings()
+
+        facts['settings'] = appliance_settings['applianceSettings']
+
+        return facts

--- a/plugins/module_utils/facts/appliance_settings.py
+++ b/plugins/module_utils/facts/appliance_settings.py
@@ -18,6 +18,6 @@ class MorpheusSettingsFactCollector(BaseFactCollector):
 
         appliance_settings = morph_api.get_appliance_settings()
 
-        facts['settings'] = appliance_settings['applianceSettings']
+        facts['morpheus_settings'] = appliance_settings['applianceSettings']
 
         return facts

--- a/plugins/module_utils/facts/appliance_system.py
+++ b/plugins/module_utils/facts/appliance_system.py
@@ -28,6 +28,6 @@ class MorpheusSystemFactCollector(BaseFactCollector):
         for k in drop_keys:
             del appliance_health['health'][k]
 
-        facts['system'] = appliance_health['health']
+        facts['morpheus_system'] = appliance_health['health']
 
         return facts

--- a/plugins/module_utils/facts/appliance_system.py
+++ b/plugins/module_utils/facts/appliance_system.py
@@ -1,0 +1,33 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+from ansible.module_utils.connection import Connection
+from ansible_collections.morpheus.core.plugins.module_utils.morpheusapi import MorpheusApi
+
+
+class MorpheusSystemFactCollector(BaseFactCollector):
+    name = 'system'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        facts = {}
+
+        connection = Connection(module._socket_path)
+        morph_api = MorpheusApi(connection)
+
+        appliance_health = morph_api.get_appliance_health()
+
+        drop_keys = [
+            'threads',
+            'database',
+            'elastic',
+            'rabbit'
+        ]
+
+        for k in drop_keys:
+            del appliance_health['health'][k]
+
+        facts['system'] = appliance_health['health']
+
+        return facts

--- a/plugins/module_utils/facts/appliance_threads.py
+++ b/plugins/module_utils/facts/appliance_threads.py
@@ -1,0 +1,23 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+from ansible.module_utils.connection import Connection
+from ansible_collections.morpheus.core.plugins.module_utils.morpheusapi import MorpheusApi
+
+
+class MorpheusThreadsFactCollector(BaseFactCollector):
+    name = 'threads'
+    _fact_ids = set()
+
+    def collect(self, module=None, collected_facts=None):
+        facts = {}
+
+        connection = Connection(module._socket_path)
+        morph_api = MorpheusApi(connection)
+
+        appliance_health = morph_api.get_appliance_health()
+
+        facts['threads'] = appliance_health['health']['threads']
+
+        return facts

--- a/plugins/module_utils/facts/appliance_threads.py
+++ b/plugins/module_utils/facts/appliance_threads.py
@@ -18,6 +18,6 @@ class MorpheusThreadsFactCollector(BaseFactCollector):
 
         appliance_health = morph_api.get_appliance_health()
 
-        facts['threads'] = appliance_health['health']['threads']
+        facts['morpheus_threads'] = appliance_health['health']['threads']
 
         return facts

--- a/plugins/module_utils/morpheusapi.py
+++ b/plugins/module_utils/morpheusapi.py
@@ -1,0 +1,32 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+name: morpheusapi
+short_description: Morpheus Api Helper Class
+description:
+    - Ansible Module Utility for interfacing with the Morpheus API
+version_added: 0.3.0
+author: James Riach
+'''
+
+APPLIANCE_SETTINGS_PATH = '/api/appliance-settings'
+HEALTH_PATH = '/api/health'
+LICENSE_PATH = '/api/license'
+
+
+class MorpheusApi():
+    def __init__(self, connection) -> None:
+        self.connection = connection
+
+    def get_appliance_settings(self):
+        response = self.connection.send_request(path=APPLIANCE_SETTINGS_PATH)
+        return response['contents']
+
+    def get_appliance_license(self):
+        response = self.connection.send_request(path=LICENSE_PATH)
+        return response['contents']
+
+    def get_appliance_health(self):
+        response = self.connection.send_request(path=HEALTH_PATH)
+        return response['contents']

--- a/plugins/modules/appliance_facts.py
+++ b/plugins/modules/appliance_facts.py
@@ -60,7 +60,7 @@ ansible_facts:
             "gather_subset": [
                 "all"
             ],
-            "license": {
+            "morpheus_license": {
                 "accountName": "MyCompany",
                 "amazonProductCodes": null,
                 "config": {},
@@ -135,7 +135,7 @@ ansible_facts:
                 "zoneTypes": null
             },
             "module_setup": true,
-            "settings": {
+            "morpheus_settings": {
                 "applianceUrl": "https://cmp.domain.tld",
                 "corsAllowed": null,
                 "currencyKey": null,

--- a/plugins/modules/appliance_facts.py
+++ b/plugins/modules/appliance_facts.py
@@ -1,0 +1,270 @@
+#!/usr/bin/python
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+module: appliance_facts
+short_description: Gather Morpheus Appliance Facts
+description:
+    - Gathers Morpheus Appliance Facts
+version_added: 0.3.0
+author: James Riach
+options:
+    gather_subset:
+        description:
+            - "Specify or restrict the facts that are gathered.
+              Possible values: C(all), C(database), C(elastic), C(license), C(rabbitmq),
+              C(settings), C(system), C(threads).
+              The minimum subset is: C(license), C(settings), C(system).
+              To specify a specific subset, use C(!all, !min) and then specify the fact(s) required."
+        type: list
+        elements: str
+        default: "all"
+    gather_timeout:
+        description:
+            - Timeout period for collecting individual facts
+        type: int
+        default: 10
+    filter:
+        description:
+            - Match facts to one of the specified patterns.
+        type: list
+        elements: str
+        default: []
+'''
+
+EXAMPLES = r'''
+- name: Gather All Facts
+  morpheus.core.appliance_facts:
+
+- name: Gather Minimum Facts
+  morpheus.core.appliance_facts:
+    gather_subset:
+      - "!all"
+
+- name: Gather License Facts
+  morpheus.core.appliance_facts:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - "license"
+'''
+
+RETURN = r'''
+ansible_facts:
+    description: Example of returned ansible_facts
+    returned: always
+    sample:
+    "ansible_facts": {
+            "gather_subset": [
+                "all"
+            ],
+            "license": {
+                "accountName": "MyCompany",
+                "amazonProductCodes": null,
+                "config": {},
+                "dateCreated": "2022-11-17T10:05:22Z",
+                "endDate": "2023-08-31T00:00:00Z",
+                "features": {
+                    "activity": true,
+                    "analytics": true,
+                    "approvalServices": true,
+                    "approvals": true,
+                    "apps": true,
+                    "archives": true,
+                    "automation": true,
+                    "automationServices": true,
+                    "backupServices": true,
+                    "backups": true,
+                    "boot": true,
+                    "buildServices": true,
+                    "clouds": true,
+                    "cmdbServices": true,
+                    "codeService": true,
+                    "cypher": true,
+                    "dashboard": true,
+                    "deploymentServices": true,
+                    "deployments": true,
+                    "discovery": true,
+                    "dnsServices": true,
+                    "groups": true,
+                    "guidance": true,
+                    "hosts": true,
+                    "identityServices": true,
+                    "imageBuilder": true,
+                    "instances": true,
+                    "ipamServices": true,
+                    "keyPairs": true,
+                    "library": true,
+                    "loadBalancerServices": true,
+                    "loadBalancers": true,
+                    "logging": true,
+                    "loggingServices": true,
+                    "migrations": true,
+                    "monitoring": true,
+                    "monitoringServices": true,
+                    "network": true,
+                    "plans": true,
+                    "pricing": true,
+                    "scheduling": true,
+                    "securityServices": true,
+                    "serviceDiscoveryServices": true,
+                    "sslCertificates": true,
+                    "storage": true,
+                    "templates": true,
+                    "tenants": true,
+                    "trustServices": true,
+                    "usage": true,
+                    "userGroups": true,
+                    "users": true,
+                    "virtualImages": true
+                },
+                "freeTrial": false,
+                "hardLimit": true,
+                "lastUpdated": "2022-11-17T10:05:22Z",
+                "maxInstances": 1000,
+                "maxMemory": 0,
+                "maxStorage": 0,
+                "multiTenant": true,
+                "productTier": "enterprise",
+                "reportStatus": true,
+                "startDate": "2022-08-22T00:00:00Z",
+                "supportLevel": "standard",
+                "whitelabel": true,
+                "zoneTypes": null
+            },
+            "module_setup": true,
+            "settings": {
+                "applianceUrl": "https://cmp.domain.tld",
+                "corsAllowed": null,
+                "currencyKey": null,
+                "currencyProvider": null,
+                "defaultRoleId": null,
+                "defaultUserRoleId": null,
+                "disableAfterAttempts": "5",
+                "disableAfterDaysInactive": null,
+                "dockerPrivilegedMode": false,
+                "enabledZoneTypes": [
+                    {
+                        "id": 4,
+                        "name": "Amazon"
+                    },
+                    {
+                        "id": 9,
+                        "name": "Azure (Public)"
+                    },
+                    {
+                        "id": 11,
+                        "name": "DigitalOcean"
+                    },
+                    {
+                        "id": 3,
+                        "name": "Morpheus"
+                    },
+                    {
+                        "id": 18,
+                        "name": "Oracle Public Cloud"
+                    },
+                    {
+                        "id": 40,
+                        "name": "PowerVC"
+                    },
+                    {
+                        "id": 17,
+                        "name": "UpCloud"
+                    },
+                    {
+                        "id": 38,
+                        "name": "VMware Fusion"
+                    },
+                    {
+                        "id": 28,
+                        "name": "VMware vCenter"
+                    },
+                    {
+                        "id": 34,
+                        "name": "vCloud Director"
+                    }
+                ],
+                "expirePwdDays": null,
+                "internalApplianceUrl": null,
+                "maintenanceMode": false,
+                "proxyDomain": null,
+                "proxyHost": null,
+                "proxyPassword": null,
+                "proxyPasswordHash": null,
+                "proxyPort": null,
+                "proxyUser": null,
+                "proxyWorkstation": null,
+                "registrationEnabled": false,
+                "smtpMailFrom": "morpheus@domain.tld",
+                "smtpPassword": null,
+                "smtpPasswordHash": null,
+                "smtpPort": "25",
+                "smtpSSL": false,
+                "smtpServer": "smtp.domain.tld",
+                "smtpTLS": true,
+                "smtpUser": null,
+                "statsRetainmentPeriod": null,
+                "warnUserDaysBefore": null
+            }
+        }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.facts.namespace import PrefixFactNamespace
+from ansible.module_utils.facts import ansible_collector
+from ansible_collections.morpheus.core.plugins.module_utils.morpheusapi import MorpheusApi
+from ansible_collections.morpheus.core.plugins.module_utils.facts.appliance_database import MorpheusDatabaseFactCollector
+from ansible_collections.morpheus.core.plugins.module_utils.facts.appliance_elastic import MorpheusElasticFactCollector
+from ansible_collections.morpheus.core.plugins.module_utils.facts.appliance_license import MorpheusLicenseFactCollector
+from ansible_collections.morpheus.core.plugins.module_utils.facts.appliance_rabbitmq import MorpheusRabbitmqFactCollector
+from ansible_collections.morpheus.core.plugins.module_utils.facts.appliance_settings import MorpheusSettingsFactCollector
+from ansible_collections.morpheus.core.plugins.module_utils.facts.appliance_system import MorpheusSystemFactCollector
+from ansible_collections.morpheus.core.plugins.module_utils.facts.appliance_threads import MorpheusThreadsFactCollector
+
+
+def run_module():
+    module = AnsibleModule(
+        argument_spec=dict(gather_subset=dict(default=["all"], required=False, type='list', elements='str'),
+                           gather_timeout=dict(default=10, required=False, type='int'),
+                           filter=dict(default=[], required=False, type='list', elements='str'),),
+        supports_check_mode=True
+    )
+
+    gather_subset = module.params['gather_subset']
+    gather_timeout = module.params['gather_timeout']
+    filter_spec = module.params['filter']
+    minimal_gather_subset = frozenset(['license', 'settings', 'system'])
+
+    collectors = [
+        MorpheusDatabaseFactCollector,
+        MorpheusElasticFactCollector,
+        MorpheusLicenseFactCollector,
+        MorpheusRabbitmqFactCollector,
+        MorpheusSettingsFactCollector,
+        MorpheusSystemFactCollector,
+        MorpheusThreadsFactCollector,
+    ]
+
+    namespace = PrefixFactNamespace(namespace_name='ansible', prefix='ansible_')
+
+    collector = ansible_collector.get_ansible_collector(all_collector_classes=collectors,
+                                                        namespace=namespace,
+                                                        filter_spec=filter_spec,
+                                                        gather_subset=gather_subset,
+                                                        gather_timeout=gather_timeout,
+                                                        minimal_gather_subset=minimal_gather_subset)
+
+    fact_results = collector.collect(module=module)
+
+    module.exit_json(ansible_facts=fact_results)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi,

I've been looking at developing some ansible modules for working with Morpheus Appliances, but before I went down the path of creating my own collection, I came across this one and thought it might fit well to contribute it here.
If this is not of interest I'll look to take this into my own collection.

Anyway, to the detail....

This PR adds an Ansible HttpApi Connection Plugin. This means one can provide an inventory of Morpheus Appliances and then use modules to manage those appliances.
In addition, I have also included an initial facts module - appliance_facts, which, via the httpapi plugin will gather a number of facts about that appliance.

An example Inventory and Playbook -:

```yaml
all:
  hosts:
    devcmp.example.tld:
      ansible_morpheus_user: johndoe
      ansible_morpheus_password: password
    testcmp.example.tld:
      ansible_morpheus_token: 12345abc-67de-89fa-12bc-345678defabc
  vars:
    ansible_network_os: morpheus.core.morpheus
    ansible_httpapi_use_ssl: true
```
```yaml
- name: Gather Appliance Facts
  hosts: all
  connection: httpapi
  gather_facts: false
  tasks:

    - name: Gather All Facts
      morpheus.core.appliance_facts:

    - name: Show Gathered Facts
      ansible.builtin.debug:
        var: ansible_facts
```

Of course I plan to build further modules, but thought an initial facts module was a good starting point.

Thanks for taking the time to review,
James